### PR TITLE
Custom Dashboard Theme CSS

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -15,6 +15,7 @@
     <%= render "shared/favicon" %>
 
     <% if current_carrier.custom_theme_css.present? %>
+      <%# NOTE: We need to handle it differently when we are ready to open letting user custom their own css %>
       <%= tag.style(current_carrier.custom_theme_css.html_safe) %>
     <% end %>
   </head>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -13,6 +13,10 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
     <%= render "shared/favicon" %>
+
+    <% if current_carrier.custom_theme_css.present? %>
+      <%= tag.style(current_carrier.custom_theme_css.html_safe) %>
+    <% end %>
   </head>
 
   <body data-controller="sidebar">

--- a/db/migrate/20230224074523_add_custom_theme_css_to_carriers.rb
+++ b/db/migrate/20230224074523_add_custom_theme_css_to_carriers.rb
@@ -1,0 +1,5 @@
+class AddCustomThemeCssToCarriers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :carriers, :custom_theme_css, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,6 +110,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_141127) do
     t.citext "subdomain", null: false
     t.citext "custom_app_host"
     t.citext "custom_api_host"
+    t.text "custom_theme_css"
     t.index ["custom_api_host"], name: "index_carriers_on_custom_api_host", unique: true
     t.index ["custom_app_host"], name: "index_carriers_on_custom_app_host", unique: true
     t.index ["sequence_number"], name: "index_carriers_on_sequence_number", unique: true, order: :desc

--- a/doc/slate/source/stylesheets/_overrides.scss
+++ b/doc/slate/source/stylesheets/_overrides.scss
@@ -2,15 +2,15 @@
 // COLORS
 ////////////////////
 
-$brand-color: #311FDA;
-$nav-bg-color: #3c4b64;
+$brand-color: #02d29d;
+$nav-bg-color: #fff;
 
 /////////////////////
 // BACKGROUND COLORS
 ////////////////////
 
 $logo-margin: 20px;
-$main-bg: #F7F7F7;
+$main-bg: #f7f7f7;
 $nav-bg: $nav-bg-color;
 $nav-active-bg: $brand-color;
 $nav-subitem-bg: $nav-bg-color;
@@ -22,12 +22,20 @@ $nav-active-parent-bg: $nav-bg-color;
 // TEXT COLORS
 ////////////////////
 
-$nav-text: #fff;
-$nav-active-text: #fff ;
-$nav-active-parent-text: #fff;
+$nav-text: #333;
+$nav-active-text: #fff;
+$nav-active-parent-text: #333;
 $main-text: #333;
 
 .logo {
   margin: 20px auto;
   max-width: 90% !important;
+}
+
+.toc-wrapper {
+  border-right: 1px solid #ccc;
+
+  .toc-link.active-parent {
+    border-left: 3px solid $brand-color;
+  }
 }


### PR DESCRIPTION
We don't expose this functionality for carriers to customize themselves yet. Because of this reason, it should be okay to do `current_carrier.custom_theme_css.html_safe` to unescape characters and font urls.

### Example
```css
@import url('https://fonts.googleapis.com/css2?family=Shantell+Sans:wght@300&display=swap');

:root {
  --cui-font-sans-serif: 'Shantell Sans', cursive;
}

.sidebar {
  --cui-sidebar-bg: #F0F4F7;
  --cui-sidebar-nav-link-color: black;
  --cui-sidebar-nav-link-icon-color: red;
}
```

## Docs Theme

<img width="3008" alt="image" src="https://user-images.githubusercontent.com/131172/221507227-b506bdd2-487e-4779-9bb1-62d2a751c90b.png">
