### PR TITLE
Fix sip trunk and sms gateway forms

### DIFF
--- a/app/forms/sip_trunk_form.rb
+++ b/app/forms/sip_trunk_form.rb
@@ -88,12 +88,6 @@ class SIPTrunkForm
     sip_trunk.save!
   end
 
-  def default_sender_options_for_select
-    default_sender_scope.map do |phone_number|
-      [ phone_number.decorated.number_formatted, phone_number.id ]
-    end
-  end
-
   def region_options_for_select
     SomlengRegion::Region.all.map do |region|
       [ region.human_name, region.alias, { data: { ip_address: region.nat_ip } } ]

--- a/app/forms/sip_trunk_form.rb
+++ b/app/forms/sip_trunk_form.rb
@@ -88,6 +88,12 @@ class SIPTrunkForm
     sip_trunk.save!
   end
 
+  def default_sender_options_for_select
+    default_sender_scope.map do |phone_number|
+      [ phone_number.decorated.number_formatted, phone_number.id ]
+    end
+  end
+
   def region_options_for_select
     SomlengRegion::Region.all.map do |region|
       [ region.human_name, region.alias, { data: { ip_address: region.nat_ip } } ]
@@ -106,6 +112,6 @@ class SIPTrunkForm
   end
 
   def default_sender_scope
-    carrier.phone_numbers.enabled
+    carrier.phone_numbers.available.where(type: :alphanumeric_sender_id)
   end
 end

--- a/app/forms/sip_trunk_form.rb
+++ b/app/forms/sip_trunk_form.rb
@@ -112,6 +112,6 @@ class SIPTrunkForm
   end
 
   def default_sender_scope
-    carrier.phone_numbers.available.where(type: :alphanumeric_sender_id)
+    carrier.phone_numbers.private.available.where(type: :alphanumeric_sender_id)
   end
 end

--- a/app/forms/sms_gateway_form.rb
+++ b/app/forms/sms_gateway_form.rb
@@ -46,12 +46,6 @@ class SMSGatewayForm
     sms_gateway.save!
   end
 
-  def default_sender_options_for_select
-    default_sender_scope.map do |phone_number|
-      [ phone_number.decorated.number_formatted, phone_number.id ]
-    end
-  end
-
   private
 
   def default_sender_scope

--- a/app/forms/sms_gateway_form.rb
+++ b/app/forms/sms_gateway_form.rb
@@ -46,9 +46,15 @@ class SMSGatewayForm
     sms_gateway.save!
   end
 
+  def default_sender_options_for_select
+    default_sender_scope.map do |phone_number|
+      [ phone_number.decorated.number_formatted, phone_number.id ]
+    end
+  end
+
   private
 
   def default_sender_scope
-    carrier.phone_numbers.enabled
+    carrier.phone_numbers.available.where(type: :alphanumeric_sender_id)
   end
 end

--- a/app/forms/sms_gateway_form.rb
+++ b/app/forms/sms_gateway_form.rb
@@ -55,6 +55,6 @@ class SMSGatewayForm
   private
 
   def default_sender_scope
-    carrier.phone_numbers.available.where(type: :alphanumeric_sender_id)
+    carrier.phone_numbers.private.available.where(type: :alphanumeric_sender_id)
   end
 end

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -4,9 +4,9 @@ class PhoneNumber < ApplicationRecord
   extend Enumerize
 
   NUMBER_FORMAT = /\A\d+\z/
-  SHORT_CODE_TYPES = [ :short_code ].freeze
-  E164_TYPES = [ :local, :mobile, :toll_free ].freeze
-  TYPES = (SHORT_CODE_TYPES + E164_TYPES).freeze
+  E164_TYPES = [ :local, :mobile, :toll_free, :alphanumeric_sender_id ].freeze
+  NON_164_TYPES = [ :short_code, :alphanumeric_sender_id ].freeze
+  TYPES = (NON_164_TYPES + E164_TYPES).uniq.freeze
 
   enumerize :type, in: TYPES
   enumerize :visibility,

--- a/app/validators/phone_number_type_validator.rb
+++ b/app/validators/phone_number_type_validator.rb
@@ -2,7 +2,7 @@ class PhoneNumberTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return record.errors.add(attribute, :blank) if value.blank?
     return if record.number.blank?
-    return if value.to_sym.in?(record.number.e164? ? PhoneNumber::E164_TYPES : PhoneNumber::SHORT_CODE_TYPES)
+    return if value.to_sym.in?(record.number.e164? ? PhoneNumber::E164_TYPES : PhoneNumber::NON_164_TYPES)
 
     record.errors.add(attribute, :invalid)
   end

--- a/spec/system/dashboard/sip_trunks_spec.rb
+++ b/spec/system/dashboard/sip_trunks_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "SIP Trunks" do
 
   it "Create a SIP Trunk", :js do
     user = create(:user, :carrier, :admin)
-    phone_number = create(:phone_number, carrier: user.carrier, number: "855715777777")
+    phone_number = create(:phone_number, carrier: user.carrier, number: "1234", type: :alphanumeric_sender_id)
 
     carrier_sign_in(user)
     visit dashboard_sip_trunks_path
@@ -43,7 +43,7 @@ RSpec.describe "SIP Trunks" do
     select("Mexico", from: "Default country code")
     fill_in("Host", with: "sip.example.com:5061")
     fill_in("Dial string prefix", with: "123456")
-    choices_select("+855 71 577 7777", from: "Default sender")
+    choices_select("1234", from: "Default sender")
     check("National dialing")
     check("Plus prefix")
     fill_in("Route prefixes", with: "85510")
@@ -58,7 +58,7 @@ RSpec.describe "SIP Trunks" do
     expect(page).to have_content("Mexico (52)")
     expect(page).to have_content("+1234560XXXXXXXX@sip.example.com:5061")
     expect(page).to have_content("Unlimited")
-    expect(page).to have_link("+855 71 577 7777", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_link("1234", href: dashboard_phone_number_path(phone_number))
   end
 
   it "Creates a SIP trunk with client credentials", :js do

--- a/spec/system/dashboard/sip_trunks_spec.rb
+++ b/spec/system/dashboard/sip_trunks_spec.rb
@@ -28,7 +28,13 @@ RSpec.describe "SIP Trunks" do
 
   it "Create a SIP Trunk", :js do
     user = create(:user, :carrier, :admin)
-    phone_number = create(:phone_number, carrier: user.carrier, number: "1234", type: :alphanumeric_sender_id)
+    alphanumeric_sender_id = create(
+      :phone_number,
+      carrier: user.carrier,
+      number: "123456",
+      type: :alphanumeric_sender_id,
+      visibility: :private
+    )
 
     carrier_sign_in(user)
     visit dashboard_sip_trunks_path
@@ -43,7 +49,7 @@ RSpec.describe "SIP Trunks" do
     select("Mexico", from: "Default country code")
     fill_in("Host", with: "sip.example.com:5061")
     fill_in("Dial string prefix", with: "123456")
-    choices_select("1234", from: "Default sender")
+    choices_select("123456", from: "Default sender")
     check("National dialing")
     check("Plus prefix")
     fill_in("Route prefixes", with: "85510")
@@ -58,7 +64,7 @@ RSpec.describe "SIP Trunks" do
     expect(page).to have_content("Mexico (52)")
     expect(page).to have_content("+1234560XXXXXXXX@sip.example.com:5061")
     expect(page).to have_content("Unlimited")
-    expect(page).to have_link("1234", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_link("123456", href: dashboard_phone_number_path(alphanumeric_sender_id))
   end
 
   it "Creates a SIP trunk with client credentials", :js do
@@ -99,7 +105,14 @@ RSpec.describe "SIP Trunks" do
   it "Update a SIP Trunk" do
     carrier = create(:carrier)
     user = create(:user, :carrier, :admin, carrier:)
-    phone_number = create(:phone_number, carrier:, number: "855715777777")
+    alphanumeric_sender_id = create(
+      :phone_number,
+      carrier:,
+      number: "123456",
+      visibility: :private,
+      type: :alphanumeric_sender_id
+    )
+
     sip_trunk = create(
       :sip_trunk,
       carrier:,
@@ -109,7 +122,7 @@ RSpec.describe "SIP Trunks" do
       outbound_dial_string_prefix: "1234",
       outbound_national_dialing: true,
       outbound_plus_prefix: true,
-      default_sender: phone_number,
+      default_sender: alphanumeric_sender_id,
       region: :helium
     )
 
@@ -137,7 +150,7 @@ RSpec.describe "SIP Trunks" do
     expect(page).to have_content("96.9.66.131")
     expect(page).to have_content("Cambodia")
     expect(page).to have_content("XXXXXXXXXXX@96.9.66.132")
-    expect(page).to have_no_link("+855 71 577 7777", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_no_link("123456", href: dashboard_phone_number_path(alphanumeric_sender_id))
   end
 
   it "Delete a SIP Trunk" do

--- a/spec/system/dashboard/sms_gateways_spec.rb
+++ b/spec/system/dashboard/sms_gateways_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe "SMS Gateways" do
 
   it "Create a SMS Gateway" do
     user = create(:user, :carrier, :admin)
-    phone_number = create(:phone_number, number: "855715777777", carrier: user.carrier)
+    phone_number = create(:phone_number, number: "1234", type: :alphanumeric_sender_id, carrier: user.carrier)
 
     carrier_sign_in(user)
     visit dashboard_sms_gateways_path
-    click_link("New")
+    click_on("New")
     fill_in("Name", with: "Main SMS Gateway")
-    choices_select("+855 71 577 7777", from: "Default sender")
+    choices_select("1234", from: "Default sender")
 
-    click_button "Create SMS gateway"
+    click_on "Create SMS gateway"
 
     expect(page).to have_content("SMS gateway was successfully created")
     expect(page).to have_content("Main SMS Gateway")
-    expect(page).to have_link("+855 71 577 7777", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_link("1234", href: dashboard_phone_number_path(phone_number))
   end
 
   it "Handles validations" do
@@ -46,7 +46,7 @@ RSpec.describe "SMS Gateways" do
 
     carrier_sign_in(user)
     visit new_dashboard_sms_gateway_path
-    click_button "Create SMS gateway"
+    click_on "Create SMS gateway"
 
     expect(page).to have_content("can't be blank")
   end
@@ -82,11 +82,11 @@ RSpec.describe "SMS Gateways" do
     carrier_sign_in(user)
     visit dashboard_sms_gateway_path(sms_gateway)
 
-    click_link("Edit")
+    click_on("Edit")
     fill_in("Name", with: "Main SMS Gateway")
     choices_select("", from: "Default sender")
 
-    click_button "Update SMS gateway"
+    click_on "Update SMS gateway"
 
     expect(page).to have_content("SMS gateway was successfully updated")
     expect(page).to have_content("Main SMS Gateway")

--- a/spec/system/dashboard/sms_gateways_spec.rb
+++ b/spec/system/dashboard/sms_gateways_spec.rb
@@ -26,19 +26,25 @@ RSpec.describe "SMS Gateways" do
 
   it "Create a SMS Gateway" do
     user = create(:user, :carrier, :admin)
-    phone_number = create(:phone_number, number: "1234", type: :alphanumeric_sender_id, carrier: user.carrier)
+    alphanumeric_sender_id = create(
+      :phone_number,
+      number: "123456",
+      type: :alphanumeric_sender_id,
+      visibility: :private,
+      carrier: user.carrier
+    )
 
     carrier_sign_in(user)
     visit dashboard_sms_gateways_path
     click_on("New")
     fill_in("Name", with: "Main SMS Gateway")
-    choices_select("1234", from: "Default sender")
+    choices_select("123456", from: "Default sender")
 
     click_on "Create SMS gateway"
 
     expect(page).to have_content("SMS gateway was successfully created")
     expect(page).to have_content("Main SMS Gateway")
-    expect(page).to have_link("1234", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_link("1234", href: dashboard_phone_number_path(alphanumeric_sender_id))
   end
 
   it "Handles validations" do
@@ -71,12 +77,18 @@ RSpec.describe "SMS Gateways" do
   it "Update a SMS Gateway" do
     carrier = create(:carrier)
     user = create(:user, :carrier, :admin, carrier:)
-    phone_number = create(:phone_number, number: "855715777777", carrier:)
+    alphanumeric_sender_id = create(
+      :phone_number,
+      number: "123456",
+      type: :alphanumeric_sender_id,
+      visibility: :private,
+      carrier:
+    )
     sms_gateway = create(
       :sms_gateway,
       carrier:,
       name: "My SMS Gateway",
-      default_sender: phone_number
+      default_sender: alphanumeric_sender_id
     )
 
     carrier_sign_in(user)
@@ -90,7 +102,7 @@ RSpec.describe "SMS Gateways" do
 
     expect(page).to have_content("SMS gateway was successfully updated")
     expect(page).to have_content("Main SMS Gateway")
-    expect(page).to have_no_link("+855 71 577 7777", href: dashboard_phone_number_path(phone_number))
+    expect(page).to have_no_link("+855 71 577 7777", href: dashboard_phone_number_path(alphanumeric_sender_id))
   end
 
   it "Delete a SMS Gateway" do

--- a/spec/validators/phone_number_type_validator_spec.rb
+++ b/spec/validators/phone_number_type_validator_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe PhoneNumberTypeValidator do
     expect(validatable_klass.new(number: "1294", type: "foobar").valid?).to eq(false)
 
     expect(validatable_klass.new(number: "1294", type: "short_code").valid?).to eq(true)
+    expect(validatable_klass.new(number: "1294", type: "alphanumeric_sender_id").valid?).to eq(true)
     expect(validatable_klass.new(number: "1294", type: "mobile").valid?).to eq(false)
     expect(validatable_klass.new(number: "1294", type: "local").valid?).to eq(false)
     expect(validatable_klass.new(number: "1294", type: "toll_free").valid?).to eq(false)
@@ -27,5 +28,6 @@ RSpec.describe PhoneNumberTypeValidator do
     expect(validatable_klass.new(number: "12513095542", type: "mobile").valid?).to eq(true)
     expect(validatable_klass.new(number: "12513095542", type: "local").valid?).to eq(true)
     expect(validatable_klass.new(number: "12513095542", type: "toll_free").valid?).to eq(true)
+    expect(validatable_klass.new(number: "12513095542", type: "alphanumeric_sender_id").valid?).to eq(true)
   end
 end


### PR DESCRIPTION
The SIP Trunk form and SMS Gateway form don't load when there are too many number in the carrier's inventory because it's loading all the phone numbers.

This PR introduces a new type Phone number type: `alphanumeric_sender_id`. Only these types can be selected when using these forms.