### PR TITLE
Tweak worker autoscaling settings

### DIFF
--- a/infrastructure/modules/somleng/worker.tf
+++ b/infrastructure/modules/somleng/worker.tf
@@ -119,7 +119,7 @@ resource "aws_appautoscaling_policy" "worker_memory_utilization" {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
 
-    target_value       = 50
+    target_value       = 75
     scale_in_cooldown  = 300
     scale_out_cooldown = 60
   }


### PR DESCRIPTION
The limit is too close to the actual value resulting in unnecessary autoscaling See below:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/fe42df44-eeed-4c71-96a8-e8c3ee2da852">
