### PR TITLE
Fix updating call status

### DIFF
--- a/app/jobs/process_cdr_job.rb
+++ b/app/jobs/process_cdr_job.rb
@@ -94,11 +94,6 @@ class ProcessCDRJob < ApplicationJob
     # https://github.com/signalwire/freeswitch/blob/6a13dee6f816c0b801676c084ab91942dd338cc5/src/mod/event_handlers/mod_json_cdr/mod_json_cdr.c#L316
     def decode_payload
       payload = ActiveSupport::Gzip.decompress(Base64.decode64(raw_payload))
-
-      json_payload = JSON.parse(payload) rescue nil
-
-      return json_payload if json_payload.present?
-
       payload = URI.decode_www_form(payload).to_h.fetch("cdr")
       payload = Base64.decode64(payload)
       payload = payload.gsub(/:(nan)/, ":null")

--- a/app/jobs/process_cdr_job.rb
+++ b/app/jobs/process_cdr_job.rb
@@ -101,7 +101,11 @@ class ProcessCDRJob < ApplicationJob
     end
   end
 
-  retry_on(Handler::UnknownPhoneCallError, wait: :polynomially_longer)
+  retry_on(
+    Handler::UnknownPhoneCallError,
+    UpdatePhoneCallStatus::InvalidStateTransitionError,
+    wait: :polynomially_longer
+  )
 
   def perform(...)
     Handler.new(...).perform

--- a/app/models/phone_call.rb
+++ b/app/models/phone_call.rb
@@ -98,7 +98,7 @@ class PhoneCall < ApplicationRecord
   end
 
   def uncompleted?
-    status.in?([ "queued", "initiating", "initiated", "ringing", "answered", "session_timeout" ])
+    status.in?([ "queued", "initiating", "initiated", "ringing", "answered" ])
   end
 
   def user_terminated?

--- a/app/models/phone_call.rb
+++ b/app/models/phone_call.rb
@@ -67,19 +67,19 @@ class PhoneCall < ApplicationRecord
     end
 
     event :complete do
-      transitions from: %i[initiated ringing answered completed], to: :completed
+      transitions from: %i[initiated ringing answered], to: :completed
     end
 
     event :mark_as_not_answered do
-      transitions from: %i[initiated ringing not_answered], to: :not_answered
+      transitions from: %i[initiated ringing], to: :not_answered
     end
 
     event :mark_as_busy do
-      transitions from: %i[initiated ringing busy], to: :busy
+      transitions from: %i[initiated ringing], to: :busy
     end
 
     event :fail do
-      transitions from: %i[initiated ringing failed], to: :failed
+      transitions from: %i[initiated ringing], to: :failed
     end
   end
 

--- a/app/workflows/update_phone_call_status.rb
+++ b/app/workflows/update_phone_call_status.rb
@@ -2,6 +2,8 @@ class UpdatePhoneCallStatus < ApplicationWorkflow
   NOT_ANSWERED_SIP_TERM_STATUSES = %w[ 480 487 603].freeze
   BUSY_SIP_TERM_STATUSES = [ "486" ].freeze
 
+  class InvalidStateTransitionError < StandardError; end
+
   attr_reader :phone_call, :event_type, :answer_epoch, :sip_term_status, :sip_invite_failure_status, :session_limiters
 
   def initialize(phone_call, event_details, **options)
@@ -18,16 +20,16 @@ class UpdatePhoneCallStatus < ApplicationWorkflow
     return handle_complete_event if event_type == :completed
     return phone_call.ring! if event_type == :ringing && phone_call.may_fire_event?(:ring)
     phone_call.answer! if event_type == :answered && phone_call.may_fire_event?(:answer)
+  rescue AASM::InvalidTransition => e
+    raise InvalidStateTransitionError, e.message
   end
 
   private
 
   def handle_complete_event
     if answer_epoch.to_i.positive?
-      unless phone_call.completed?
-        phone_call.complete!
-        create_interaction
-      end
+      phone_call.complete!
+      create_interaction
     elsif NOT_ANSWERED_SIP_TERM_STATUSES.include?(sip_term_status)
       phone_call.mark_as_not_answered!
     elsif BUSY_SIP_TERM_STATUSES.include?(sip_term_status)

--- a/app/workflows/update_phone_call_status.rb
+++ b/app/workflows/update_phone_call_status.rb
@@ -27,6 +27,8 @@ class UpdatePhoneCallStatus < ApplicationWorkflow
   private
 
   def handle_complete_event
+    return if phone_call.status.in?([ "completed", "not_answered", "busy", "canceled", "failed" ])
+
     if answer_epoch.to_i.positive?
       phone_call.complete!
       create_interaction

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,7 @@
 Sentry.init do |config|
   config.dsn = Rails.configuration.app_settings[:sentry_dsn]
+  config.excluded_exceptions += [
+    "ProcessCDRJob::Handler::UnknownPhoneCallError",
+    "UpdatePhoneCallStatus::InvalidStateTransitionError,"
+  ]
 end

--- a/spec/workflows/update_phone_call_status_spec.rb
+++ b/spec/workflows/update_phone_call_status_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe UpdatePhoneCallStatus do
     expect(phone_call.status).to eq("busy")
   end
 
+  it "handles invalid state transitions" do
+    phone_call = create(:phone_call, status: :session_timeout)
+
+    expect {
+      UpdatePhoneCallStatus.call(
+        phone_call,
+        {
+          event_type: "completed",
+          answer_epoch: "1585814727",
+          sip_term_status: "200"
+        }
+      )
+    }.to raise_error(UpdatePhoneCallStatus::InvalidStateTransitionError)
+  end
+
   def build_session_limiters(account:, sessions: {}, **)
     session_limiters = [ AccountCallSessionLimiter.new(**), GlobalCallSessionLimiter.new(**) ]
 

--- a/spec/workflows/update_phone_call_status_spec.rb
+++ b/spec/workflows/update_phone_call_status_spec.rb
@@ -135,6 +135,21 @@ RSpec.describe UpdatePhoneCallStatus do
     }.to raise_error(UpdatePhoneCallStatus::InvalidStateTransitionError)
   end
 
+  it "handles repeated events" do
+    phone_call = create(:phone_call, :initiated, :failed)
+
+    UpdatePhoneCallStatus.call(
+      phone_call,
+      {
+        event_type: "completed",
+        answer_epoch: "0",
+        sip_term_status: "404"
+      }
+    )
+
+    expect(phone_call.status).to eq("failed")
+  end
+
   def build_session_limiters(account:, sessions: {}, **)
     session_limiters = [ AccountCallSessionLimiter.new(**), GlobalCallSessionLimiter.new(**) ]
 


### PR DESCRIPTION
## Todo

- [x] Handle updating status better
- [x] Ignore Sentry errors for UnknownPhoneCallError
- [x] Remove conditional code when decoding the CDR
- [x] In UpdatePhoneCallStatus don't update the session limit for both CDR and PhoneCallEvents